### PR TITLE
add erwa as dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ rel/example_project
 .erlang.mk.*
 _rel/
 logs/
+
+awre.iml
+.idea
+.erlang.mk

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,8 @@ ERLC_OPTS = +debug_info
 
 COMPILE_FIRST = awre_transport.erl
 
-DEPS = wamper
-dep_wamper = git https://github.com/bwegh/wamper master
-
-TEST_DEPS = erwa
-dep_erwa = git https://github.com/bwegh/erwa master
+DEPS = wamper erwa
+dep_wamper = git https://github.com/comtihon/wamper master
+dep_erwa = git https://github.com/comtihon/erwa master
 
 include erlang.mk

--- a/src/awre.erl
+++ b/src/awre.erl
@@ -26,156 +26,148 @@
 
 %% API for connecting to a router (either local or remote)
 -export([start_client/0]).
--export([stop_client/1,stop_client/3]).
+-export([stop_client/1, stop_client/3]).
 
 -export([connect/2]).
 -export([connect/5]).
 
--export([subscribe/3,subscribe/4]).
+-export([subscribe/3, subscribe/4]).
 -export([unsubscribe/2]).
--export([publish/3,publish/4,publish/5]).
+-export([publish/3, publish/4, publish/5]).
 
--export([register/3,register/4]).
+-export([register/3, register/4]).
 -export([unregister/2]).
--export([call/3,call/4,call/5]).
--export([yield/3,yield/4,yield/5]).
+-export([call/3, call/4, call/5]).
+-export([yield/3, yield/4, yield/5]).
 -export([error/5]).
 
 
 -export([get_version/0]).
 
 %% @doc returns the version string for the application, used as agent description
--spec get_version() -> Version::binary().
+-spec get_version() -> Version :: binary().
 get_version() ->
   Ver = case application:get_key(vsn) of
-    {ok, V} -> list_to_binary(V);
-    _ -> <<"UNKNOWN">>
-  end,
-  << <<"Awre-">>/binary, Ver/binary >>.
-
-
+          {ok, V} -> list_to_binary(V);
+          _ -> <<"UNKNOWN">>
+        end,
+  <<<<"Awre-">>/binary, Ver/binary>>.
 
 %% connecting to a (remote) router (for peer)
 
 %% @doc start a connection server to handle a connection to a router.
 %% The connection can be either remote or local within the VM.
--spec start_client() -> {ok,Con :: pid()}.
+-spec start_client() -> {ok, Con :: pid()}.
 start_client() ->
-  supervisor:start_child(awre_sup,[[]]).
+  awre_sup:start_client().
 
 %% @doc stop the given connection
 %% TODO: implement
--spec stop_client(ConPid :: pid(),Details :: list(),Reason :: binary()) -> ok.
-stop_client(ConPid,Details,Reason) ->
-  gen_server:cast(ConPid,{shutdown,Details,Reason}).
+-spec stop_client(ConPid :: pid(), Details :: list(), Reason :: binary()) -> ok.
+stop_client(ConPid, Details, Reason) ->
+  gen_server:cast(ConPid, {shutdown, Details, Reason}).
 
 -spec stop_client(ConPid :: pid()) -> ok.
 stop_client(ConPid) ->
-  gen_server:cast(ConPid,{shutdown,#{},goodbye_and_out}).
+  gen_server:cast(ConPid, {shutdown, #{}, goodbye_and_out}).
 
 %% @doc Connect to a router in the VM.
 %% The connection will be established to the local router in the VM.
--spec connect(ConPid :: pid(), Realm :: binary()) -> {ok,SessionId :: non_neg_integer() ,RouterDetails :: list()}.
-connect(ConPid,Realm) ->
-  gen_server:call(ConPid,{awre_call,{connect,undefined,undefined,Realm,undefined}}).
+-spec connect(ConPid :: pid(), Realm :: binary()) -> {ok, SessionId :: non_neg_integer(), RouterDetails :: list()}.
+connect(ConPid, Realm) ->
+  gen_server:call(ConPid, {awre_call, {connect, undefined, undefined, Realm, undefined}}).
 
 %% @doc connect to a remote router.
 %% Connect to the router at the given host Host on port Port to the realm Realm.
 %% The connection will be established by using the encoding Encoding for serialization.
 %% The connection wil be a direct TCP connection, there is no support for websocket connections.
--spec connect(ConPid :: pid(), Host :: string(), Port :: non_neg_integer(), Realm :: binary(), Encoding :: raw_json | raw_msgpack) -> {ok,SessionId :: non_neg_integer() ,RouterDetails :: list()}.
-connect(ConPid,Host,Port,Realm,Encoding) ->
-  gen_server:call(ConPid,{awre_call,{connect,Host,Port,Realm,Encoding}}).
-
-
+-spec connect(ConPid :: pid(), Host :: string(), Port :: non_neg_integer(), Realm :: binary(), Encoding :: raw_json | raw_msgpack) -> {ok, SessionId :: non_neg_integer(), RouterDetails :: list()}.
+connect(ConPid, Host, Port, Realm, Encoding) ->
+  gen_server:call(ConPid, {awre_call, {connect, Host, Port, Realm, Encoding}}).
 
 %% @doc Subscribe to an event.
 %% subscribe to the event Topic.
 %% On an event the Mfa wil be called as:
 %% Module:Function(Details, Arguments, ArgumentsKw, Argument),
 %% the last Argument will be the one from the Mfa, given at subscription time.
--spec subscribe(ConPid :: pid(), Options :: list(), Topic :: binary(), Mfa :: {atom,atom,any()} | undefined) -> {ok,SubscriptionId :: non_neg_integer()}.
-subscribe(ConPid,Options,Topic,Mfa) ->
-  gen_server:call(ConPid,{awre_call,{subscribe,Options,Topic,Mfa}}).
-
+-spec subscribe(ConPid :: pid(), Options :: list(), Topic :: binary(), Mfa :: {atom, atom, any()} | undefined) -> {ok, SubscriptionId :: non_neg_integer()}.
+subscribe(ConPid, Options, Topic, Mfa) ->
+  gen_server:call(ConPid, {awre_call, {subscribe, Options, Topic, Mfa}}).
 
 %% @doc Subscribe to an event.
--spec subscribe(ConPid :: pid(), Options :: list(), Topic :: binary()) -> {ok,SubscriptionId :: non_neg_integer()}.
-subscribe(ConPid,Options,Topic) ->
-  subscribe(ConPid,Options,Topic,undefined).
-
+-spec subscribe(ConPid :: pid(), Options :: list(), Topic :: binary()) -> {ok, SubscriptionId :: non_neg_integer()}.
+subscribe(ConPid, Options, Topic) ->
+  subscribe(ConPid, Options, Topic, undefined).
 
 %% @doc Unsubscribe from an event.
 -spec unsubscribe(ConPid :: pid(), SubscriptionId :: non_neg_integer()) -> ok.
-unsubscribe(ConPid,SubscriptionId) ->
-  gen_server:call(ConPid,{awre_call,{unsubscribe,SubscriptionId}}).
+unsubscribe(ConPid, SubscriptionId) ->
+  gen_server:call(ConPid, {awre_call, {unsubscribe, SubscriptionId}}).
 
 %% @doc Publish an event.
 -spec publish(ConPid :: pid(), Options :: list(), Topic :: binary()) -> ok.
-publish(ConPid,Options,Topic) ->
-  publish(ConPid,Options,Topic,undefined,undefined).
+publish(ConPid, Options, Topic) ->
+  publish(ConPid, Options, Topic, undefined, undefined).
 
 %% @doc Publish an event.
 -spec publish(ConPid :: pid(), Options :: list(), Topic :: binary(), Arguments :: list() | undefined) -> ok.
-publish(ConPid,Options,Topic,Arguments)->
-  publish(ConPid,Options,Topic,Arguments,undefined).
+publish(ConPid, Options, Topic, Arguments) ->
+  publish(ConPid, Options, Topic, Arguments, undefined).
 
 %% @doc Publish an event.
 -spec publish(ConPid :: pid(), Options :: list(), Topic :: binary(), Arguments :: list() | undefined, ArgumentsKw :: list() | undefined) -> ok.
-publish(ConPid,Options,Topic,Arguments,ArgumentsKw) ->
-  gen_server:call(ConPid,{awre_call,{publish,Options,Topic,Arguments,ArgumentsKw}}).
+publish(ConPid, Options, Topic, Arguments, ArgumentsKw) ->
+  gen_server:call(ConPid, {awre_call, {publish, Options, Topic, Arguments, ArgumentsKw}}).
 
 %% @doc Register a remote procedure.
--spec register(ConPid :: pid(), Options :: list(), Procedure :: binary()) -> {ok, RegistrationId :: non_neg_integer() }.
-register(ConPid,Options,Procedure) ->
-  register(ConPid,Options,Procedure,undefined).
+-spec register(ConPid :: pid(), Options :: list(), Procedure :: binary()) -> {ok, RegistrationId :: non_neg_integer()}.
+register(ConPid, Options, Procedure) ->
+  register(ConPid, Options, Procedure, undefined).
 
 %% @doc Register a remote procedure.
--spec register(ConPid :: pid(), Options :: list(), Procedure :: binary(), Mfa :: {atom,atom,any()}|undefined) -> {ok, RegistrationId :: non_neg_integer() }.
-register(ConPid,Options,Procedure,Mfa) ->
-  gen_server:call(ConPid,{awre_call,{register,Options,Procedure,Mfa}}).
+-spec register(ConPid :: pid(), Options :: list(), Procedure :: binary(), Mfa :: {atom, atom, any()}|undefined) -> {ok, RegistrationId :: non_neg_integer()}.
+register(ConPid, Options, Procedure, Mfa) ->
+  gen_server:call(ConPid, {awre_call, {register, Options, Procedure, Mfa}}).
 
 %% @doc Unregister a remote procedure.
 -spec unregister(ConPid :: pid(), RegistrationId :: non_neg_integer()) -> ok.
-unregister(ConPid,RegistrationId) ->
-  gen_server:call(ConPid,{awre_call,{unregister, RegistrationId}}).
-
+unregister(ConPid, RegistrationId) ->
+  gen_server:call(ConPid, {awre_call, {unregister, RegistrationId}}).
 
 %% @doc Call a remote procedure.
 -spec call(ConPid :: pid(), Options :: list(), ProcedureUrl :: binary()) -> {ok, Details :: list(), ResA :: list() | undefined, ResAKw :: list() | undefined}.
-call(ConPid,Options,ProcedureUrl) ->
-  call(ConPid,Options,ProcedureUrl,undefined,undefined).
+call(ConPid, Options, ProcedureUrl) ->
+  call(ConPid, Options, ProcedureUrl, undefined, undefined).
 
 %% @doc Call a remote procedure.
--spec call(ConPid :: pid(), Options :: list(), ProcedureUrl :: binary(), Arguments::list()) -> {ok, Details :: list(), ResA :: list() | undefined, ResAKw :: list() | undefined}.
-call(ConPid,Options,ProcedureUrl,Arguments) ->
-  call(ConPid,Options,ProcedureUrl,Arguments,undefined).
+-spec call(ConPid :: pid(), Options :: list(), ProcedureUrl :: binary(), Arguments :: list()) -> {ok, Details :: list(), ResA :: list() | undefined, ResAKw :: list() | undefined}.
+call(ConPid, Options, ProcedureUrl, Arguments) ->
+  call(ConPid, Options, ProcedureUrl, Arguments, undefined).
 
 %% @doc Call a remote procedure.
--spec call(ConPid :: pid(), Options :: list(), ProcedureUrl :: binary(), Arguments::list() | undefined , ArgumentsKw :: list() | undefined) -> {ok, Details :: list(), ResA :: list() | undefined, ResAKw :: list() | undefined}.
-call(ConPid,Options,ProcedureUrl,Arguments,ArgumentsKw) ->
-  gen_server:call(ConPid,{awre_call,{call,Options,ProcedureUrl,Arguments,ArgumentsKw}}).
-
-
-%% @doc Return the result to a call.
--spec yield(ConPid :: pid(), RequestId :: non_neg_integer(), Details :: list() ) -> ok.
-yield(ConPid,RequestId,Details) ->
-  yield(ConPid,RequestId,Details,undefined,undefined).
+-spec call(ConPid :: pid(), Options :: list(), ProcedureUrl :: binary(), Arguments :: list() | undefined, ArgumentsKw :: list() | undefined) -> {ok, Details :: list(), ResA :: list() | undefined, ResAKw :: list() | undefined}.
+call(ConPid, Options, ProcedureUrl, Arguments, ArgumentsKw) ->
+  gen_server:call(ConPid, {awre_call, {call, Options, ProcedureUrl, Arguments, ArgumentsKw}}).
 
 %% @doc Return the result to a call.
--spec yield(ConPid :: pid(), RequestId :: non_neg_integer(), Details :: list(), Arguments :: list() ) -> ok.
-yield(ConPid,RequestId,Details,Arguments) ->
-  yield(ConPid,RequestId,Details,Arguments,undefined).
+-spec yield(ConPid :: pid(), RequestId :: non_neg_integer(), Details :: list()) -> ok.
+yield(ConPid, RequestId, Details) ->
+  yield(ConPid, RequestId, Details, undefined, undefined).
 
 %% @doc Return the result to a call.
--spec yield(ConPid :: pid(), RequestId :: non_neg_integer(), Details :: list(), Arguments :: list() | undefined, ArgumentsKw :: list() | undefined ) -> ok.
-yield(ConPid,RequestId,Details,Arguments,ArgumentsKw) ->
-  gen_server:call(ConPid,{awre_call,{yield,RequestId,Details,Arguments,ArgumentsKw}}).
+-spec yield(ConPid :: pid(), RequestId :: non_neg_integer(), Details :: list(), Arguments :: list()) -> ok.
+yield(ConPid, RequestId, Details, Arguments) ->
+  yield(ConPid, RequestId, Details, Arguments, undefined).
+
+%% @doc Return the result to a call.
+-spec yield(ConPid :: pid(), RequestId :: non_neg_integer(), Details :: list(), Arguments :: list() | undefined, ArgumentsKw :: list() | undefined) -> ok.
+yield(ConPid, RequestId, Details, Arguments, ArgumentsKw) ->
+  gen_server:call(ConPid, {awre_call, {yield, RequestId, Details, Arguments, ArgumentsKw}}).
 
 %% @doc Return an error from a call.
-error(ConPid,RequestId,ErrorType,Reason,ErrorUri) ->
-  ReasonStr = iolist_to_binary(io_lib:format("~p:~p",[ErrorType,Reason])),
+error(ConPid, RequestId, ErrorType, Reason, ErrorUri) ->
+  ReasonStr = iolist_to_binary(io_lib:format("~p:~p", [ErrorType, Reason])),
   StackTraceStr = iolist_to_binary(io_lib:format("~p", [erlang:get_stacktrace()])),
   ArgsKw = #{<<"reason">> => ReasonStr,
-            <<"stacktrace">> => StackTraceStr},
-  gen_server:call(ConPid, {awre_call,{error,invocation,RequestId,ArgsKw,ErrorUri}}).
+    <<"stacktrace">> => StackTraceStr},
+  gen_server:call(ConPid, {awre_call, {error, invocation, RequestId, ArgsKw, ErrorUri}}).

--- a/src/awre_app.erl
+++ b/src/awre_app.erl
@@ -29,10 +29,8 @@
 -export([stop/1]).
 
 %% API.
-
 start(_Type, _Args) ->
   awre_sup:start_link().
-
 
 stop(_State) ->
 	ok.

--- a/src/awre_con.erl
+++ b/src/awre_con.erl
@@ -40,45 +40,45 @@
 -export([code_change/3]).
 
 -define(CLIENT_DETAILS, #{
-                          callee => #{features => #{}},
-                          caller => #{features => #{}},
-                          publisher => #{features => #{}},
-                          subscriber => #{features => #{}}
-                          }).
+  callee => #{features => #{}},
+  caller => #{features => #{}},
+  publisher => #{features => #{}},
+  subscriber => #{features => #{}}
+}).
 
--record(state,{
-               ets = undefined,
-               goodbye_sent = false,
+-record(state, {
+  ets = undefined,
+  goodbye_sent = false,
 
-               transport = {none,none},
+  transport = {none, none},
 
-               subscribe_id=1,
-               unsubscribe_id=1,
-               publish_id=1,
-               register_id=1,
-               unregister_id=1,
-               call_id=1
+  subscribe_id = 1,
+  unsubscribe_id = 1,
+  publish_id = 1,
+  register_id = 1,
+  unregister_id = 1,
+  call_id = 1
 
-  }).
+}).
 
 -record(ref, {
-              key = {none,none},
-              req = undefined,
-              method = undefined,
-              ref=undefined,
-              args = []
-              }).
+  key = {none, none},
+  req = undefined,
+  method = undefined,
+  ref = undefined,
+  args = []
+}).
 
--record(subscription,{
+-record(subscription, {
   id = undefined,
   mfa = undefined,
-  pid=undefined}).
+  pid = undefined}).
 
--record(registration,{
+-record(registration, {
   id = undefined,
   mfa = undefined,
   pid = undefined
-                      }).
+}).
 
 
 -spec start_link(Args :: map()) -> {ok, pid()}.
@@ -87,242 +87,241 @@ start_link(Args) ->
 
 
 
--spec init(Args :: map() ) -> {ok,#state{}}.
+-spec init(Args :: map()) -> {ok, #state{}}.
 init(_Args) ->
-  Ets = ets:new(con_data,[set,protected,{keypos,2}]),
-  {ok,#state{ets=Ets}}.
+  Ets = ets:new(con_data, [set, protected, {keypos, 2}]),
+  {ok, #state{ets = Ets}}.
 
 
 -spec send_to_client(Msg :: term(), Pid :: pid()) -> ok.
-send_to_client(Msg,Pid) ->
-  gen_server:cast(Pid,{awre_out,Msg}).
+send_to_client(Msg, Pid) ->
+  gen_server:cast(Pid, {awre_out, Msg}).
 
 
 close_connection(Pid) ->
-  gen_server:cast(Pid,terminate).
+  gen_server:cast(Pid, terminate).
 
 
--spec handle_call(Msg :: term(), From :: term(), #state{}) -> {reply,Msg :: term(), #state{}}.
-handle_call({awre_call,Msg},From,State) ->
-  handle_message_from_client(Msg,From,State);
-handle_call(_Msg,_From,State) ->
-  {noreply,State}.
+-spec handle_call(Msg :: term(), From :: term(), #state{}) -> {reply, Msg :: term(), #state{}}.
+handle_call({awre_call, Msg}, From, State) ->
+  handle_message_from_client(Msg, From, State);
+handle_call(_Msg, _From, State) ->
+  {noreply, State}.
 
 
-handle_cast({awre_out,Msg}, State) ->
-  {ok,NewState} = handle_message_from_router(Msg,State),
-  {noreply,NewState};
-handle_cast({shutdown,Details,Reason}, #state{goodbye_sent=GS,transport= {TMod,TState}}=State) ->
+handle_cast({awre_out, Msg}, State) ->
+  {ok, NewState} = handle_message_from_router(Msg, State),
+  {noreply, NewState};
+handle_cast({shutdown, Details, Reason}, #state{goodbye_sent = GS, transport = {TMod, TState}} = State) ->
   NewState = case GS of
                true ->
                  State;
                false ->
-                 {ok,NewTState} = TMod:send_to_router({goodbye,Details,Reason},TState),
-                 State#state{transport={TMod,NewTState}}
+                 {ok, NewTState} = TMod:send_to_router({goodbye, Details, Reason}, TState),
+                 State#state{transport = {TMod, NewTState}}
              end,
-  {noreply,NewState#state{goodbye_sent=true}};
+  {noreply, NewState#state{goodbye_sent = true}};
 
-handle_cast(terminate,#state{transport={TMod,TState}} = State) ->
+handle_cast(terminate, #state{transport = {TMod, TState}} = State) ->
   ok = TMod:shutdown(TState),
-  {stop,normal,State};
+  {stop, normal, State};
 
 handle_cast(_Request, State) ->
-	{noreply, State}.
+  {noreply, State}.
 
 
 
 
 
-handle_info(Data,#state{transport = {T,TState}} = State) ->
-  {ok,NewTState} = T:handle_info(Data,TState),
-  {noreply,State#state{transport={T,NewTState}}};
+handle_info(Data, #state{transport = {T, TState}} = State) ->
+  {ok, NewTState} = T:handle_info(Data, TState),
+  {noreply, State#state{transport = {T, NewTState}}};
 handle_info(_Info, State) ->
-	{noreply, State}.
+  {noreply, State}.
 
 terminate(_Reason, _State) ->
-	ok.
+  ok.
 
 code_change(_OldVsn, State, _Extra) ->
-	{ok, State}.
+  {ok, State}.
 
 
 -spec handle_message_from_client(Msg :: term(), From :: term(), State :: #state{}) ->
   {noreply, #state{}} | {reply, Result :: term(), #state{}}.
-handle_message_from_client({connect,Host,Port,Realm,Encoding}=Msg,From,
-                           #state{transport={T,_}}=State) ->
-
+handle_message_from_client({connect, Host, Port, Realm, Encoding} = Msg, From,
+    #state{transport = {T, _}} = State) ->
   Args = #{awre_con => self(), host => Host, port => Port, realm => Realm, enc => Encoding,
-           version => awre:get_version(), client_details => ?CLIENT_DETAILS},
-  {Trans,TState} = case T of
-                         none ->
-                           awre_transport:init(Args);
-                         T ->
-                           NewTState = T:init(Args),
-                           {T,NewTState}
-                       end,
-  {_,NewState} = create_ref_for_message(Msg,From,#{},State),
-  {noreply,NewState#state{transport={Trans,TState}}};
-handle_message_from_client({subscribe,Options,Topic,Mfa},From,State) ->
-  {ok,NewState} = send_and_ref({subscribe,request_id,Options,Topic},From,#{mfa => Mfa},State),
-  {noreply,NewState};
-handle_message_from_client({unsubscribe,SubscriptionId},From,State) ->
-  {ok,NewState} = send_and_ref({unsubscribe,request_id,SubscriptionId},From,#{sub_id=>SubscriptionId},State),
-  {noreply,NewState};
-handle_message_from_client({publish,Options,Topic,Arguments,ArgumentsKw},From,State) ->
-  {ok,NewState} = send_and_ref({publish,request_id,Options,Topic,Arguments,ArgumentsKw},From,#{},State),
-  {reply,ok,NewState};
-handle_message_from_client({register,Options,Procedure,Mfa},From,State) ->
-  {ok,NewState} = send_and_ref({register,request_id,Options,Procedure},From,#{mfa=>Mfa},State),
-  {noreply,NewState};
-handle_message_from_client({unregister,RegistrationId},From,State) ->
-  {ok,NewState} = send_and_ref({unregister,request_id,RegistrationId},From,#{reg_id => RegistrationId},State),
-  {noreply,NewState};
-handle_message_from_client({call,Options,Procedure,Arguments,ArgumentsKw},From,State) ->
-  {ok,NewState} = send_and_ref({call,request_id,Options,Procedure,Arguments,ArgumentsKw},From,#{},State),
-  {noreply,NewState};
-handle_message_from_client({yield,_,_,_,_}=Msg,_From,State) ->
-  {ok,NewState} = send_to_router(Msg,State),
-  {reply,ok,NewState};
-handle_message_from_client({error,invocation,RequestId,ArgsKw,ErrorUri},_From,State) ->
-  {ok,NewState} = send_to_router({error,invocation,RequestId,#{},ErrorUri,[],ArgsKw},State),
-  {reply,ok,NewState};
-handle_message_from_client(_Msg,_From,State) ->
-  {noreply,State}.
+    version => awre:get_version(), client_details => ?CLIENT_DETAILS},
+  {Trans, TState} = case T of
+                      none ->
+                        awre_transport:init(Args);
+                      T ->
+                        NewTState = T:init(Args),
+                        {T, NewTState}
+                    end,
+  {_, NewState} = create_ref_for_message(Msg, From, #{}, State),
+  {noreply, NewState#state{transport = {Trans, TState}}};
+handle_message_from_client({subscribe, Options, Topic, Mfa}, From, State) ->
+  {ok, NewState} = send_and_ref({subscribe, request_id, Options, Topic}, From, #{mfa => Mfa}, State),
+  {noreply, NewState};
+handle_message_from_client({unsubscribe, SubscriptionId}, From, State) ->
+  {ok, NewState} = send_and_ref({unsubscribe, request_id, SubscriptionId}, From, #{sub_id=>SubscriptionId}, State),
+  {noreply, NewState};
+handle_message_from_client({publish, Options, Topic, Arguments, ArgumentsKw}, From, State) ->
+  {ok, NewState} = send_and_ref({publish, request_id, Options, Topic, Arguments, ArgumentsKw}, From, #{}, State),
+  {reply, ok, NewState};
+handle_message_from_client({register, Options, Procedure, Mfa}, From, State) ->
+  {ok, NewState} = send_and_ref({register, request_id, Options, Procedure}, From, #{mfa=>Mfa}, State),
+  {noreply, NewState};
+handle_message_from_client({unregister, RegistrationId}, From, State) ->
+  {ok, NewState} = send_and_ref({unregister, request_id, RegistrationId}, From, #{reg_id => RegistrationId}, State),
+  {noreply, NewState};
+handle_message_from_client({call, Options, Procedure, Arguments, ArgumentsKw}, From, State) ->
+  {ok, NewState} = send_and_ref({call, request_id, Options, Procedure, Arguments, ArgumentsKw}, From, #{}, State),
+  {noreply, NewState};
+handle_message_from_client({yield, _, _, _, _} = Msg, _From, State) ->
+  {ok, NewState} = send_to_router(Msg, State),
+  {reply, ok, NewState};
+handle_message_from_client({error, invocation, RequestId, ArgsKw, ErrorUri}, _From, State) ->
+  {ok, NewState} = send_to_router({error, invocation, RequestId, #{}, ErrorUri, [], ArgsKw}, State),
+  {reply, ok, NewState};
+handle_message_from_client(_Msg, _From, State) ->
+  {noreply, State}.
 
 
 
 
-handle_message_from_router({welcome,SessionId,RouterDetails},State) ->
-  {From,_} = get_ref(hello,hello,State),
-  gen_server:reply(From,{ok,SessionId,RouterDetails}),
-  {ok,State};
+handle_message_from_router({welcome, SessionId, RouterDetails}, State) ->
+  {From, _} = get_ref(hello, hello, State),
+  gen_server:reply(From, {ok, SessionId, RouterDetails}),
+  {ok, State};
 
-handle_message_from_router({abort,Details,Reason},State) ->
-  {From,_} = get_ref(hello,hello,State),
-  gen_server:reply(From,{abort,Details,Reason}),
-  {stop,normal,State};
+handle_message_from_router({abort, Details, Reason}, State) ->
+  {From, _} = get_ref(hello, hello, State),
+  gen_server:reply(From, {abort, Details, Reason}),
+  {stop, normal, State};
 
-handle_message_from_router({goodbye,_Details,_Reason},#state{goodbye_sent=GS}=State) ->
+handle_message_from_router({goodbye, _Details, _Reason}, #state{goodbye_sent = GS} = State) ->
   NewState = case GS of
                true ->
                  State;
                false ->
-                 {ok,NState} = send_to_router({goodbye,[],goodbye_and_out},State),
+                 {ok, NState} = send_to_router({goodbye, [], goodbye_and_out}, State),
                  NState
              end,
   close_connection(),
-  {ok,NewState};
+  {ok, NewState};
 
 %handle_message_from_router({error,},#state{ets=Ets}) ->
 
 %handle_message_from_router({published,},#state{ets=Ets}) ->
 
-handle_message_from_router({subscribed,RequestId,SubscriptionId},#state{ets=Ets}=State) ->
-  {From,Args} = get_ref(RequestId,subscribe,State),
-  Mfa = maps:get(mfa,Args),
-  {Pid,_} = From,
-  ets:insert_new(Ets,#subscription{id=SubscriptionId,mfa=Mfa,pid=Pid}),
-  gen_server:reply(From,{ok,SubscriptionId}),
-  {ok,State};
+handle_message_from_router({subscribed, RequestId, SubscriptionId}, #state{ets = Ets} = State) ->
+  {From, Args} = get_ref(RequestId, subscribe, State),
+  Mfa = maps:get(mfa, Args),
+  {Pid, _} = From,
+  ets:insert_new(Ets, #subscription{id = SubscriptionId, mfa = Mfa, pid = Pid}),
+  gen_server:reply(From, {ok, SubscriptionId}),
+  {ok, State};
 
-handle_message_from_router({unsubscribed,RequestId},#state{ets=Ets}=State) ->
-  {From,Args} = get_ref(RequestId,unsubscribe,State),
-  SubscriptionId = maps:get(sub_id,Args),
-  ets:delete(Ets,SubscriptionId),
-  gen_server:reply(From,ok),
-  {ok,State};
+handle_message_from_router({unsubscribed, RequestId}, #state{ets = Ets} = State) ->
+  {From, Args} = get_ref(RequestId, unsubscribe, State),
+  SubscriptionId = maps:get(sub_id, Args),
+  ets:delete(Ets, SubscriptionId),
+  gen_server:reply(From, ok),
+  {ok, State};
 
-handle_message_from_router({event,SubscriptionId,PublicationId,Details},State) ->
-  handle_message_from_router({event,SubscriptionId,PublicationId,Details,undefined,undefined},State);
-handle_message_from_router({event,SubscriptionId,PublicationId,Details,Arguments},State) ->
-  handle_message_from_router({event,SubscriptionId,PublicationId,Details,Arguments,undefined},State);
-handle_message_from_router({event,SubscriptionId,_PublicationId,Details,Arguments,ArgumentsKw}=Msg,#state{ets=Ets}=State) ->
+handle_message_from_router({event, SubscriptionId, PublicationId, Details}, State) ->
+  handle_message_from_router({event, SubscriptionId, PublicationId, Details, undefined, undefined}, State);
+handle_message_from_router({event, SubscriptionId, PublicationId, Details, Arguments}, State) ->
+  handle_message_from_router({event, SubscriptionId, PublicationId, Details, Arguments, undefined}, State);
+handle_message_from_router({event, SubscriptionId, _PublicationId, Details, Arguments, ArgumentsKw} = Msg, #state{ets = Ets} = State) ->
   [#subscription{
-                id = SubscriptionId,
-                mfa = Mfa,
-                pid=Pid}] = ets:lookup(Ets,SubscriptionId),
+    id = SubscriptionId,
+    mfa = Mfa,
+    pid = Pid}] = ets:lookup(Ets, SubscriptionId),
   case Mfa of
     undefined ->
       % send it to user process
-      Pid ! {awre,Msg};
-    {M,F,S}  ->
+      Pid ! {awre, Msg};
+    {M, F, S} ->
       try
-        erlang:apply(M,F,[Details,Arguments,ArgumentsKw,S])
+        erlang:apply(M, F, [Details, Arguments, ArgumentsKw, S])
       catch
         Error:Reason ->
-          io:format("error ~p:~p with event: ~n~p~n",[Error,Reason,erlang:get_stacktrace()])
+          io:format("error ~p:~p with event: ~n~p~n", [Error, Reason, erlang:get_stacktrace()])
       end
   end,
-  {ok,State};
-handle_message_from_router({result,RequestId,Details},State) ->
-  handle_message_from_router({result,RequestId,Details,undefined,undefined},State);
-handle_message_from_router({result,RequestId,Details,Arguments},State) ->
-  handle_message_from_router({result,RequestId,Details,Arguments,undefined},State);
-handle_message_from_router({result,RequestId,Details,Arguments,ArgumentsKw},State) ->
-  {From,_} = get_ref(RequestId,call,State),
-  gen_server:reply(From,{ok,Details,Arguments,ArgumentsKw}),
-  {ok,State};
+  {ok, State};
+handle_message_from_router({result, RequestId, Details}, State) ->
+  handle_message_from_router({result, RequestId, Details, undefined, undefined}, State);
+handle_message_from_router({result, RequestId, Details, Arguments}, State) ->
+  handle_message_from_router({result, RequestId, Details, Arguments, undefined}, State);
+handle_message_from_router({result, RequestId, Details, Arguments, ArgumentsKw}, State) ->
+  {From, _} = get_ref(RequestId, call, State),
+  gen_server:reply(From, {ok, Details, Arguments, ArgumentsKw}),
+  {ok, State};
 
-handle_message_from_router({registered,RequestId,RegistrationId},#state{ets=Ets}=State) ->
-  {From,Args} = get_ref(RequestId,register,State),
-  Mfa = maps:get(mfa,Args),
-  {Pid,_} = From,
-  ets:insert_new(Ets,#registration{id=RegistrationId,mfa=Mfa,pid=Pid}),
-  gen_server:reply(From,{ok,RegistrationId}),
-  {ok,State};
+handle_message_from_router({registered, RequestId, RegistrationId}, #state{ets = Ets} = State) ->
+  {From, Args} = get_ref(RequestId, register, State),
+  Mfa = maps:get(mfa, Args),
+  {Pid, _} = From,
+  ets:insert_new(Ets, #registration{id = RegistrationId, mfa = Mfa, pid = Pid}),
+  gen_server:reply(From, {ok, RegistrationId}),
+  {ok, State};
 
-handle_message_from_router({unregistered,RequestId},#state{ets=Ets}=State) ->
-  {From,Args} = get_ref(RequestId,unregister,State),
-  RegistrationId = maps:get(reg_id,Args),
-  ets:delete(Ets,RegistrationId),
-  gen_server:reply(From,ok),
-  {ok,State};
+handle_message_from_router({unregistered, RequestId}, #state{ets = Ets} = State) ->
+  {From, Args} = get_ref(RequestId, unregister, State),
+  RegistrationId = maps:get(reg_id, Args),
+  ets:delete(Ets, RegistrationId),
+  gen_server:reply(From, ok),
+  {ok, State};
 
-handle_message_from_router({invocation,RequestId,RegistrationId,Details},State) ->
-  handle_message_from_router({invocation,RequestId,RegistrationId,Details,undefined,undefined},State);
-handle_message_from_router({invocation,RequestId,RegistrationId,Details,Arguments},State) ->
-  handle_message_from_router({invocation,RequestId,RegistrationId,Details,Arguments,undefined},State);
-handle_message_from_router({invocation,RequestId,RegistrationId,Details,Arguments,ArgumentsKw}=Msg,#state{ets=Ets}=State) ->
+handle_message_from_router({invocation, RequestId, RegistrationId, Details}, State) ->
+  handle_message_from_router({invocation, RequestId, RegistrationId, Details, undefined, undefined}, State);
+handle_message_from_router({invocation, RequestId, RegistrationId, Details, Arguments}, State) ->
+  handle_message_from_router({invocation, RequestId, RegistrationId, Details, Arguments, undefined}, State);
+handle_message_from_router({invocation, RequestId, RegistrationId, Details, Arguments, ArgumentsKw} = Msg, #state{ets = Ets} = State) ->
   [#registration{
-                id = RegistrationId,
-                mfa = Mfa,
-                pid=Pid}] = ets:lookup(Ets,RegistrationId),
+    id = RegistrationId,
+    mfa = Mfa,
+    pid = Pid}] = ets:lookup(Ets, RegistrationId),
   NewState = case Mfa of
                undefined ->
                  % send it to the user process
-                 Pid ! {awre,Msg},
+                 Pid ! {awre, Msg},
                  State;
-               {M,F,S}  ->
-                 try erlang:apply(M,F,[Details,Arguments,ArgumentsKw,S]) of
-                   {ok,Options,ResA,ResAKw} ->
-                     {ok,NState} = send_to_router({yield,RequestId,Options,ResA,ResAKw},State),
+               {M, F, S} ->
+                 try erlang:apply(M, F, [Details, Arguments, ArgumentsKw, S]) of
+                   {ok, Options, ResA, ResAKw} ->
+                     {ok, NState} = send_to_router({yield, RequestId, Options, ResA, ResAKw}, State),
                      NState;
-                   {error,Details,Uri,Arguments,ArgumentsKw} ->
-                     {ok,NState} = send_to_router({error,invocation,RequestId,Details,Uri,Arguments,ArgumentsKw},State),
+                   {error, Details, Uri, Arguments, ArgumentsKw} ->
+                     {ok, NState} = send_to_router({error, invocation, RequestId, Details, Uri, Arguments, ArgumentsKw}, State),
                      NState;
                    Other ->
-                     {ok,NState} = send_to_router({error,invocation,RequestId,#{<<"result">> => Other },invalid_argument,undefined,undefined},State),
+                     {ok, NState} = send_to_router({error, invocation, RequestId, #{<<"result">> => Other}, invalid_argument, undefined, undefined}, State),
                      NState
                  catch
                    Error:Reason ->
-                     {ok,NState} = send_to_router({error,invocation,RequestId,#{<<"reason">> => io_lib:format("~p:~p",[Error,Reason])},invalid_argument,undefined,undefined},State),
+                     {ok, NState} = send_to_router({error, invocation, RequestId, #{<<"reason">> => io_lib:format("~p:~p", [Error, Reason])}, invalid_argument, undefined, undefined}, State),
                      NState
                  end
              end,
-  {ok,NewState};
+  {ok, NewState};
 
-handle_message_from_router({error,call,RequestId,Details,Error},State) ->
-  handle_message_from_router({error,call,RequestId,Details,Error,undefined,undefined},State);
-handle_message_from_router({error,call,RequestId,Details,Error,Arguments},State) ->
-  handle_message_from_router({error,call,RequestId,Details,Error,Arguments,undefined},State);
-handle_message_from_router({error,call,RequestId,Details,Error,Arguments,ArgumentsKw},State) ->
-  {From,_} = get_ref(RequestId,call,State),
-  gen_server:reply(From,{error,Details,Error,Arguments,ArgumentsKw}),
-  {ok,State};
+handle_message_from_router({error, call, RequestId, Details, Error}, State) ->
+  handle_message_from_router({error, call, RequestId, Details, Error, undefined, undefined}, State);
+handle_message_from_router({error, call, RequestId, Details, Error, Arguments}, State) ->
+  handle_message_from_router({error, call, RequestId, Details, Error, Arguments, undefined}, State);
+handle_message_from_router({error, call, RequestId, Details, Error, Arguments, ArgumentsKw}, State) ->
+  {From, _} = get_ref(RequestId, call, State),
+  gen_server:reply(From, {error, Details, Error, Arguments, ArgumentsKw}),
+  {ok, State};
 
-handle_message_from_router(Msg,State) ->
-  io:format("unhandled message ~p~n",[Msg]),
-  {ok,State}.
+handle_message_from_router(Msg, State) ->
+  io:format("unhandled message ~p~n", [Msg]),
+  {ok, State}.
 
 %
 % Session Scope IDs
@@ -349,56 +348,56 @@ handle_message_from_router(Msg,State) ->
 % (for each direction - Client-to-Router and Router-to-Client)
 %
 
-send_and_ref(Msg,From,Args,State) ->
-  {Message,NewState} = create_ref_for_message(Msg,From,Args,State),
-  send_to_router(Message,NewState).
+send_and_ref(Msg, From, Args, State) ->
+  {Message, NewState} = create_ref_for_message(Msg, From, Args, State),
+  send_to_router(Message, NewState).
 
-send_to_router(Msg,#state{transport={TMod,TState}} = State) ->
-  {ok,NewTState} = TMod:send_to_router(Msg,TState),
-  {ok,State#state{transport={TMod,NewTState}}}.
+send_to_router(Msg, #state{transport = {TMod, TState}} = State) ->
+  {ok, NewTState} = TMod:send_to_router(Msg, TState),
+  {ok, State#state{transport = {TMod, NewTState}}}.
 
-create_ref_for_message(Msg,From,Args,#state{ets=Ets}=State)  ->
-  Method = case element(1,Msg) of
+create_ref_for_message(Msg, From, Args, #state{ets = Ets} = State) ->
+  Method = case element(1, Msg) of
              connect -> hello;
              El -> El
            end,
-  {RequestId,NewState} = case Method of
-                           hello ->
-                             {hello,State};
-                           subscribe ->
-                             Id = State#state.subscribe_id,
-                             {Id,State#state{subscribe_id = Id+1}};
-                           unsubscribe ->
-                             Id = State#state.unsubscribe_id,
-                             {Id,State#state{unsubscribe_id = Id+1}};
-                           publish ->
-                             Id = State#state.publish_id,
-                             {Id,State#state{publish_id = Id+1}};
-                           register ->
-                             Id = State#state.register_id,
-                             {Id,State#state{register_id = Id+1}};
-                           unregister ->
-                             Id = State#state.unregister_id,
-                             {Id,State#state{unregister_id = Id+1}};
-                           call ->
-                             Id = State#state.call_id,
-                             {Id,State#state{call_id = Id+1}}
-                         end,
-  true = ets:insert_new(Ets,#ref{key={Method,RequestId},ref=From,args=Args}),
+  {RequestId, NewState} = case Method of
+                            hello ->
+                              {hello, State};
+                            subscribe ->
+                              Id = State#state.subscribe_id,
+                              {Id, State#state{subscribe_id = Id + 1}};
+                            unsubscribe ->
+                              Id = State#state.unsubscribe_id,
+                              {Id, State#state{unsubscribe_id = Id + 1}};
+                            publish ->
+                              Id = State#state.publish_id,
+                              {Id, State#state{publish_id = Id + 1}};
+                            register ->
+                              Id = State#state.register_id,
+                              {Id, State#state{register_id = Id + 1}};
+                            unregister ->
+                              Id = State#state.unregister_id,
+                              {Id, State#state{unregister_id = Id + 1}};
+                            call ->
+                              Id = State#state.call_id,
+                              {Id, State#state{call_id = Id + 1}}
+                          end,
+  true = ets:insert_new(Ets, #ref{key = {Method, RequestId}, ref = From, args = Args}),
   case is_integer(RequestId) of
     true ->
-      {setelement(2,Msg,RequestId),NewState};
+      {setelement(2, Msg, RequestId), NewState};
     false ->
-      {Msg,NewState}
+      {Msg, NewState}
   end.
 
 
 
-get_ref(ReqId,Method,#state{ets=Ets}) ->
-  Key = {Method,ReqId},
-  [#ref{ref=From,args=Args}] = ets:lookup(Ets,Key),
-  ets:delete(Ets,Key),
-  {From,Args}.
+get_ref(ReqId, Method, #state{ets = Ets}) ->
+  Key = {Method, ReqId},
+  [#ref{ref = From, args = Args}] = ets:lookup(Ets, Key),
+  ets:delete(Ets, Key),
+  {From, Args}.
 
 close_connection() ->
-  gen_server:cast(self(),terminate).
+  gen_server:cast(self(), terminate).

--- a/src/awre_sup.erl
+++ b/src/awre_sup.erl
@@ -26,12 +26,15 @@
 -behaviour(supervisor).
 
 %% API.
--export([start_link/0]).
+-export([start_link/0, start_client/0]).
 
 %% supervisor.
 -export([init/1]).
 
 %% API.
+
+start_client() ->
+	supervisor:start_child(?MODULE, [[]]).
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->

--- a/src/awre_transport.erl
+++ b/src/awre_transport.erl
@@ -26,20 +26,15 @@
 -export([init/1]).
 
 
--callback init(Args :: map()) -> {ok,State :: any()}.
+-callback init(Args :: map()) -> {ok, State :: any()}.
 -callback send_to_router(Message :: term(), State :: any()) -> {ok, NewState :: any()}.
 -callback handle_info(Data :: any(), State :: any()) -> {ok, NewState :: any()}.
 -callback shutdown(State :: any()) -> ok.
 
 
-
+init(Args = #{host := undefined}) ->
+ {ok, State} = awre_trans_local:init(Args),
+  {awre_trans_local, State};
 init(Args) ->
-  #{host := Host} = Args,
-  Module = case Host == undefined of
-             true ->
-               awre_trans_local;
-             false ->
-               awre_trans_tcp
-           end,
-  {ok,State} = Module:init(Args),
-  {Module,State}.
+  {ok, State} = awre_trans_tcp:init(Args),
+  {awre_trans_tcp, State}.


### PR DESCRIPTION
add erwa as ordinary dep (not test) as it is used in project.
Run autoformatting and refactored `awre_transport:init/1` to make IDE search&refactoring search transport implementations.
No logic changes.
